### PR TITLE
Changed Javascript Imports to fix build errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 import "./main.css";
-require('firebase/firebase-auth');
-require('firebase/firebase-firestore');
-const firebase = require('firebase/firebase-app');
-
+import * as firebase from "firebase/app";
+import "firebase/firebase-auth";
+import "firebase/firebase-firestore";
 
 import { Elm } from "./Main.elm";
 import registerServiceWorker from "./registerServiceWorker";

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import "./main.css";
-import * as firebase from "firebase/app";
-import "firebase/auth";
-import "firebase/firestore";
+require('firebase/firebase-auth');
+require('firebase/firebase-firestore');
+const firebase = require('firebase/firebase-app');
+
 
 import { Elm } from "./Main.elm";
 import registerServiceWorker from "./registerServiceWorker";


### PR DESCRIPTION
Previously, the auth and firestore imports were being redirected to the `empty-import.d.ts`, but renaming them fixes it. Now `npm run build` correctly builds the file.

Let me know if there are any other errors!